### PR TITLE
reset should set vr to zero

### DIFF
--- a/ring_buffer.go
+++ b/ring_buffer.go
@@ -40,6 +40,7 @@ func NewWithData(data []byte) *RingBuffer {
 func (r *RingBuffer) WithData(data []byte) {
 	r.r = 0
 	r.w = 0
+	r.vr = 0
 	r.isEmpty = false
 	r.size = len(data)
 	r.buf = data
@@ -396,6 +397,7 @@ func (r *RingBuffer) IsEmpty() bool {
 
 func (r *RingBuffer) Reset() {
 	r.r = 0
+	r.vr = 0
 	r.w = 0
 	r.isEmpty = true
 }


### PR DESCRIPTION
WithData and Reset should reset vr to zero, or reuse ringbuffer raise slice outrange read.

[gev](https://github.com/Allenxuxu/gev/blob/master/connection/connection.go#L228) if here handle protocol data have remains vr value, next time reuse `c.buffer` the vr is not equals to r then do VirtualRead will raise error.