### PR TITLE
after makespace should recompute vr value

### DIFF
--- a/ring_buffer.go
+++ b/ring_buffer.go
@@ -407,6 +407,7 @@ func (r *RingBuffer) String() string {
 }
 
 func (r *RingBuffer) makeSpace(len int) {
+	vlen := r.VirtualLength()
 	newSize := r.size + len
 	newBuf := make([]byte, newSize, newSize)
 	oldLen := r.Length()
@@ -414,6 +415,7 @@ func (r *RingBuffer) makeSpace(len int) {
 
 	r.w = oldLen
 	r.r = 0
+	r.vr = oldLen - vlen
 	r.size = newSize
 	r.buf = newBuf
 }


### PR DESCRIPTION
after makespace, should recompute vr value. [gev](https://github.com/Allenxuxu/gev/blob/master/connection/connection.go#L235) here will trigger ringbuffer makespace operation, if vr value is not zero, next time using VirtualRead to read will get error data.