### PR TITLE
feat: improve buffer grow and shrink

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,39 @@ func main() {
 }
 ```
 
+## 扩容
+
+ringbuffer底层存储结构为golang切片。当ringbuffer需要扩容时，扩容策略参考golang切片append策略:  
+https://github.com/golang/go/blob/ac0ba6707c1655ea4316b41d06571a0303cc60eb/src/runtime/slice.go#L125  
+1. 如果期望容量大于当前容量的两倍就会使用期望容量；
+2. 如果当前切片的长度小于 1024 就会将容量翻倍；
+3. 如果当前切片的长度大于 1024 就会每次增加 25% 的容量，直到新容量大于期望容量；
+
+当调用ringbuffer.Reset()时，buffer将会缩容回初始化时的大小。
+
+```go
+rb := New(2)
+fmt.Println(rb.Length())   // 0
+fmt.Println(rb.Capacity()) // 2
+
+rb.Write([]byte("abc"))
+fmt.Println(rb.Length())   // 3
+fmt.Println(rb.Capacity()) // 4
+
+rb.Write([]byte(strings.Repeat("a", 1024)))
+fmt.Println(rb.Length())   // 1027
+fmt.Println(rb.Capacity()) // 1027
+
+rb.WriteByte('a')
+fmt.Println(rb.Length())   // 1028
+fmt.Println(rb.Capacity()) // 1283
+
+rb.Reset()
+fmt.Println(rb.Length())   // 0
+fmt.Println(rb.Capacity()) // 2
+``` 
+
+
 ## 参考
 
 https://github.com/smallnest/ringbuffer

--- a/ring_buffer_benchmark_test.go
+++ b/ring_buffer_benchmark_test.go
@@ -16,3 +16,15 @@ func BenchmarkRingBuffer_Sync(b *testing.B) {
 		_, _ = rb.Read(buf)
 	}
 }
+
+func BenchmarkRingBuffer_Grow(b *testing.B) {
+	rb := New(512)
+	data := []byte(strings.Repeat("a", 600))
+	buf := make([]byte, 512)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = rb.Write(data)
+		_, _ = rb.Read(buf)
+	}
+}

--- a/ring_buffer_test.go
+++ b/ring_buffer_test.go
@@ -30,8 +30,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 64 {
-		t.Fatalf("expect free 64 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 
 	// check retrieve
@@ -40,7 +40,7 @@ func TestRingBuffer_Write(t *testing.T) {
 		t.Fatalf("write failed: %v", err)
 	}
 	if n != 8 {
-		t.Fatalf("expect write 4 bytes but got %d", n)
+		t.Fatalf("expect write 8 bytes but got %d", n)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte(strings.Repeat("abcd", 2))) {
 		t.Fatalf("expect 8 abcdabcd but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -49,8 +49,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 3 {
 		t.Fatalf("expect len 1 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 61 {
-		t.Fatalf("expect free 61 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte(strings.Repeat("bcd", 1))) {
 		t.Fatalf("expect 1 bcd but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -65,8 +65,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 63 {
 		t.Fatalf("expect len 63 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 1 {
-		t.Fatalf("expect free 1 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte("bcd"+strings.Repeat("abcd", 15))) {
 		t.Fatalf("expect 63 ... but got %s. buf %s. r.w=%d, r.r=%d", rb.Bytes(), rb.buf, rb.w, rb.r)
@@ -84,8 +84,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 16 {
 		t.Fatalf("expect len 16 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 48 {
-		t.Fatalf("expect free 48 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte(strings.Repeat("abcd", 4))) {
 		t.Fatalf("expect 4 abcd but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -110,8 +110,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 64 {
 		t.Fatalf("expect len 64 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 0 {
-		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if rb.w != 0 {
 		t.Fatalf("expect r.w=0 but got %d. r.r=%d", rb.w, rb.r)
@@ -133,16 +133,16 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 68 {
 		t.Fatalf("expect len 68 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 0 {
-		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 
 	// check empty or full
 	if rb.IsEmpty() {
 		t.Fatalf("expect IsEmpty is false but got true")
 	}
-	if !rb.IsFull() {
-		t.Fatalf("expect IsFull is true but got false")
+	if rb.IsFull() {
+		t.Fatalf("expect IsFull is false but got true")
 	}
 
 	// reset this ringbuffer and set a long slice
@@ -154,10 +154,10 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.Length() != 80 {
 		t.Fatalf("expect len 80 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 0 {
-		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
-	if rb.w != 0 {
+	if rb.w != 80 {
 		t.Fatalf("expect r.w=0 but got %d. r.r=%d", rb.w, rb.r)
 	}
 
@@ -165,8 +165,8 @@ func TestRingBuffer_Write(t *testing.T) {
 	if rb.IsEmpty() {
 		t.Fatalf("expect IsEmpty is false but got true")
 	}
-	if !rb.IsFull() {
-		t.Fatalf("expect IsFull is true but got false")
+	if rb.IsFull() {
+		t.Fatalf("expect IsFull is false but got true")
 	}
 
 	if !bytes.Equal(rb.Bytes(), []byte(strings.Repeat("abcd", 20))) {
@@ -187,8 +187,8 @@ func TestRingBuffer_Read(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 64 {
-		t.Fatalf("expect free 64 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 
 	// read empty
@@ -206,8 +206,8 @@ func TestRingBuffer_Read(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 64 {
-		t.Fatalf("expect free 64 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if rb.r != 0 {
 		t.Fatalf("expect r.r=0 but got %d. r.w=%d", rb.r, rb.w)
@@ -225,8 +225,8 @@ func TestRingBuffer_Read(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 bytes but got %d. r.w=%d, r.r=%d, r.isEmpy=%t", rb.Length(), rb.w, rb.r, rb.isEmpty)
 	}
-	if rb.free() != 64 {
-		t.Fatalf("expect free 64 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if rb.r != 16 {
 		t.Fatalf("expect r.r=16 but got %d. r.w=%d", rb.r, rb.w)
@@ -244,10 +244,10 @@ func TestRingBuffer_Read(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 80 {
-		t.Fatalf("expect free 80 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
-	if rb.r != 0 {
+	if rb.r != 80 {
 		t.Fatalf("expect r.r=16 but got %d. r.w=%d", rb.r, rb.w)
 	}
 
@@ -269,8 +269,8 @@ func TestRingBuffer_Peek(t *testing.T) {
 	if rb.Length() != 8 {
 		t.Fatalf("expect len 8 bytes but got %d. r.w=%d, r.r=%d, r.isEmpy=%t", rb.Length(), rb.w, rb.r, rb.isEmpty)
 	}
-	if rb.free() != 8 {
-		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d bytes but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if rb.r != 8 {
 		t.Fatalf("expect r.r=8 but got %d. r.w=%d", rb.r, rb.w)
@@ -337,8 +337,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 1 {
 		t.Fatalf("expect len 1 byte but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 1 {
-		t.Fatalf("expect free 1 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte{'a'}) {
 		t.Fatalf("expect a but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -359,8 +359,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 2 {
 		t.Fatalf("expect len 2 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 0 {
-		t.Fatalf("expect free 0 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte{'a', 'b'}) {
 		t.Fatalf("expect a but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -378,11 +378,11 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 3 {
 		t.Fatalf("expect len 3 bytes but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.Capacity() != 3 {
+	if rb.Capacity() != 4 {
 		t.Fatalf("expect Capacity 3 bytes but got %d. r.w=%d, r.r=%d", rb.Capacity(), rb.w, rb.r)
 	}
-	if rb.free() != 0 {
-		t.Fatalf("expect free 0 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte{'a', 'b', 'c'}) {
 		t.Fatalf("expect a but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -391,8 +391,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.IsEmpty() {
 		t.Fatalf("expect IsEmpty is false but got true")
 	}
-	if !rb.IsFull() {
-		t.Fatalf("expect IsFull is true but got false")
+	if rb.IsFull() {
+		t.Fatalf("expect IsFull is false but got true")
 	}
 
 	// read one
@@ -406,8 +406,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 2 {
 		t.Fatalf("expect len 2 byte but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 1 {
-		t.Fatalf("expect free 1 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	if !bytes.Equal(rb.Bytes(), []byte{'b', 'c'}) {
 		t.Fatalf("expect a but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
@@ -431,8 +431,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 1 {
 		t.Fatalf("expect len 1 byte but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 2 {
-		t.Fatalf("expect free 2 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 
 	// read three, error
@@ -440,8 +440,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 byte but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 3 {
-		t.Fatalf("expect free 3 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	// check empty or full
 	if !rb.IsEmpty() {
@@ -459,8 +459,8 @@ func TestRingBuffer_ByteInterface(t *testing.T) {
 	if rb.Length() != 0 {
 		t.Fatalf("expect len 0 byte but got %d. r.w=%d, r.r=%d", rb.Length(), rb.w, rb.r)
 	}
-	if rb.free() != 3 {
-		t.Fatalf("expect free 3 byte but got %d. r.w=%d, r.r=%d", rb.free(), rb.w, rb.r)
+	if rb.free() != len(rb.buf)-rb.Length() {
+		t.Fatalf("expect free %d byte but got %d. r.w=%d, r.r=%d", len(rb.buf)-rb.Length(), rb.free(), rb.w, rb.r)
 	}
 	// check empty or full
 	if !rb.IsEmpty() {
@@ -487,7 +487,7 @@ func TestNewWithData(t *testing.T) {
 	if rBuf.Length() != len(buf) {
 		t.Fatal()
 	}
-	if rBuf.free() != 0 {
+	if rBuf.free() != len(rBuf.buf)-rBuf.Length() {
 		t.Fatal()
 	}
 


### PR DESCRIPTION
## Suggestion
### capacity growth method
I think the buffer capacity growth method can be improved 
The method used in the current version is once the buffer slice needs to be expanded , then Reallocates a new slice 
https://github.com/Allenxuxu/ringbuffer/blob/02ee0d30c0341038876c4feaf502b5fbf68ac3c4/ring_buffer.go#L412
i think  go standard library growth method is better :
https://github.com/golang/go/blob/ac0ba6707c1655ea4316b41d06571a0303cc60eb/src/runtime/slice.go#L125
In the scenario of frequent capacity expansion, the performance gap is very large:
```go

func BenchmarkRingBuffer_Grow(b *testing.B) {
	b.Run("old", func(b *testing.B) {
		rb := ringbuffer.New(512)
		data := []byte(strings.Repeat("a", 600))
		buf := make([]byte, 512)

		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_, _ = rb.Write(data)
			_, _ = rb.Read(buf)
		}
	})
	b.Run("new", func(b *testing.B) {
		rb := New(512)
		data := []byte(strings.Repeat("a", 600))
		buf := make([]byte, 512)

		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_, _ = rb.Write(data)
			_, _ = rb.Read(buf)
		}
	})

}
/**
goos: linux
goarch: amd64
pkg: ringbuffer
cpu: Intel(R) Xeon(R) Platinum 8269CY CPU @ 2.50GHz
BenchmarkRingBuffer_Grow/old-2         	   10000	    845247 ns/op
BenchmarkRingBuffer_Grow/new-2         	 1000000	      2351 ns/op
**/
```
### shrink the underlying array
I think an infinite buffer should provide a way to shrink the underlying array
At least , i think in the Reset function , it may should reset the buffer to the initial size .
